### PR TITLE
add unambigious license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ You have to repeat this process for each app, which quickly becomes tedious. no_
 
 ## Licenses
 
+[![GPL-3.0-only](https://img.shields.io/badge/License-GPL--3.0--only-blue.svg)](https://spdx.org/licenses/GPL-3.0-only.html)
+
 Here is a subset of some of the works that are used NoMoreBackground.
 Please view the license page in-app for the full list.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,2 @@
+I take security very seriously. If you believe you have found a
+security issue, please email me at adilhanney@disroot.org.


### PR DESCRIPTION
* unfortunately github doesnt provide precise license template !
* this is inspired:  For Clarity's Sake, Please Don't Say “Licensed under GNU GPL 2”! by Richard Stallman https://www.gnu.org/licenses/identify-licenses-clearly.html