### PR TITLE
feat(android): language picker

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,8 @@
     <application
         android:label="NoMoreBackground"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:localeConfig="@xml/locale_config">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/xml/locale_config.xml
+++ b/android/app/src/main/res/xml/locale_config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en"/>
+    <locale android:name="ar"/>
+    <locale android:name="el"/>
+    <locale android:name="es"/>
+    <locale android:name="fil"/>
+    <locale android:name="fr"/>
+    <locale android:name="pt"/>
+    <locale android:name="ru"/>
+    <locale android:name="zh-Hans-CN"/>
+    <locale android:name="zh-Hant-TW"/>
+</locale-config>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable Android per‑app language picker. Users on Android 13+ can choose the app language from system settings.

- **New Features**
  - Added `res/xml/locale_config.xml` with: en, ar, el, es, fil, fr, pt, ru, zh-Hans-CN, zh-Hant-TW.
  - Linked via `android:localeConfig` in `AndroidManifest.xml`.

Note: Saber is trialling Cubic AI code review. AI output may contain mistakes, misconceptions, and hallucinations. You can act on the AI feedback if you find it helpful; otherwise you can disregard it and wait for a human reviewer.

<sup>Written for commit 8d9625f323f8e473cf9f269535b3bda65d7e82f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

